### PR TITLE
Fix missing honeypot config directory

### DIFF
--- a/scripts_honeypot/01_setup.sh
+++ b/scripts_honeypot/01_setup.sh
@@ -5,6 +5,15 @@ set -e
 BASE_DIR="honeypot"
 
 echo "==> Creando directorios en $BASE_DIR..."
-mkdir -p $BASE_DIR/{ftp,web,volumenes/apache_logs,volumenes/mysql_log,volumenes/ftp_logs,volumenes/config}
+mkdir -p \ 
+  "$BASE_DIR/ftp" \ 
+  "$BASE_DIR/web" \ 
+  "$BASE_DIR/volumenes/apache_logs" \ 
+  "$BASE_DIR/volumenes/mysql_log" \ 
+  "$BASE_DIR/volumenes/ftp_logs" \ 
+  "$BASE_DIR/volumenes/fakessh_logs" \ 
+  "$BASE_DIR/volumenes/mysql_data" \ 
+  "$BASE_DIR/volumenes/config" \ 
+  "$BASE_DIR/config"
 
 echo "Estructura inicial preparada."


### PR DESCRIPTION
## Summary
- ensure `scripts_honeypot/01_setup.sh` creates all needed directories

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d9a9e2654832a8c0c8a0f3f3dea6a