### PR TITLE
Add IP masking controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,14 @@ Los servicios simulados generan logs que se almacenan en volúmenes locales dent
 
 Promtail los recolecta y envía a Loki, donde se almacenan y están disponibles para consulta.
 
+### Ocultar IPs en Grafana
+Puedes mantener las direcciones IP completas en Loki y decidir desde Grafana si deseas mostrarlas o ocultar los dos últimos octetos.
+Para ello puedes crear dos variables de tipo `Text box` en el dashboard:
+- `ip_mask_regex` con el valor `(\d+\.\d+)\.\d+\.\d+`
+- `ip_mask_replace` con el valor `$1.x.x`
+
+Aplica una transformación **Replace field values** en la tabla que muestre las IPs y usa las variables anteriores en las opciones *Find* y *Replace*.
+Cambiando estas variables a `(.*)` y `$1` podrás ver las IP completas cuando lo necesites.
 Estarán automáticamente creados en el apartado de dashboards los dashboards necesarios para la correcta visualización de todos los servicios.
 
 Las métricas del sistema (uso de CPU, memoria, etc.) se recogen con Node Exporter y se visualizan en Grafana mediante Prometheus.

--- a/scripts_monitor/dashboards/apache_grafana.json
+++ b/scripts_monitor/dashboards/apache_grafana.json
@@ -247,6 +247,14 @@
               "path": "Path"
             }
           }
+        },
+        {
+          "id": "regexReplace",
+          "options": {
+            "pattern": "$ip_mask_regex",
+            "replacement": "$ip_mask_replace",
+            "field": "Ip"
+          }
         }
       ],
       "type": "table"
@@ -322,6 +330,14 @@
           "id": "labelsToFields",
           "options": {
             "mode": "values"
+          }
+        },
+        {
+          "id": "regexReplace",
+          "options": {
+            "pattern": "$ip_mask_regex",
+            "replacement": "$ip_mask_replace",
+            "field": "remote_ip"
           }
         }
       ],
@@ -454,7 +470,7 @@
         },
         "exemplars": false,
         "filterValues": {
-          "le": 1e-9
+          "le": 1E-9
         },
         "legend": {
           "show": true
@@ -514,6 +530,26 @@
         "query": "loki",
         "refresh": 1,
         "type": "datasource"
+      },
+      {
+        "name": "ip_mask_regex",
+        "type": "textbox",
+        "label": "IP mask regex",
+        "query": "(\\d+\\.\\d+)\\.\\d+\\.\\d+",
+        "current": {
+          "text": "(\\d+\\.\\d+)\\.\\d+\\.\\d+",
+          "value": "(\\d+\\.\\d+)\\.\\d+\\.\\d+"
+        }
+      },
+      {
+        "name": "ip_mask_replace",
+        "type": "textbox",
+        "label": "IP mask replace",
+        "query": "$1.x.x",
+        "current": {
+          "text": "$1.x.x",
+          "value": "$1.x.x"
+        }
       }
     ]
   },

--- a/scripts_monitor/dashboards/mysql_dashboard.json
+++ b/scripts_monitor/dashboards/mysql_dashboard.json
@@ -270,6 +270,14 @@
               "__value__": "Errors"
             }
           }
+        },
+        {
+          "id": "regexReplace",
+          "options": {
+            "pattern": "$ip_mask_regex",
+            "replacement": "$ip_mask_replace",
+            "field": "IP"
+          }
         }
       ],
       "type": "table"
@@ -788,7 +796,23 @@
         }
       ],
       "title": "Top 10 IPs por número de consultas",
-      "type": "table"
+      "type": "table",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "mode": "values"
+          }
+        },
+        {
+          "id": "regexReplace",
+          "options": {
+            "pattern": "$ip_mask_regex",
+            "replacement": "$ip_mask_replace",
+            "field": "remote_ip"
+          }
+        }
+      ]
     },
     {
       "datasource": "$DS_LOKI",
@@ -871,6 +895,26 @@
         "query": "loki",
         "refresh": 1,
         "type": "datasource"
+      },
+      {
+        "name": "ip_mask_regex",
+        "type": "textbox",
+        "label": "IP mask regex",
+        "query": "(\\d+\\.\\d+)\\.\\d+\\.\\d+",
+        "current": {
+          "text": "(\\d+\\.\\d+)\\.\\d+\\.\\d+",
+          "value": "(\\d+\\.\\d+)\\.\\d+\\.\\d+"
+        }
+      },
+      {
+        "name": "ip_mask_replace",
+        "type": "textbox",
+        "label": "IP mask replace",
+        "query": "$1.x.x",
+        "current": {
+          "text": "$1.x.x",
+          "value": "$1.x.x"
+        }
       }
     ]
   },

--- a/scripts_monitor/mysql_dashboard2.json
+++ b/scripts_monitor/mysql_dashboard2.json
@@ -535,7 +535,23 @@
         }
       ],
       "title": "Top 10 IPs por número de consultas",
-      "type": "table"
+      "type": "table",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "mode": "values"
+          }
+        },
+        {
+          "id": "regexReplace",
+          "options": {
+            "pattern": "$ip_mask_regex",
+            "replacement": "$ip_mask_replace",
+            "field": "remote_ip"
+          }
+        }
+      ]
     },
     {
       "datasource": "$DS_LOKI",
@@ -615,6 +631,26 @@
         "query": "loki",
         "refresh": 1,
         "type": "datasource"
+      },
+      {
+        "name": "ip_mask_regex",
+        "type": "textbox",
+        "label": "IP mask regex",
+        "query": "(\\d+\\.\\d+)\\.\\d+\\.\\d+",
+        "current": {
+          "text": "(\\d+\\.\\d+)\\.\\d+\\.\\d+",
+          "value": "(\\d+\\.\\d+)\\.\\d+\\.\\d+"
+        }
+      },
+      {
+        "name": "ip_mask_replace",
+        "type": "textbox",
+        "label": "IP mask replace",
+        "query": "$1.x.x",
+        "current": {
+          "text": "$1.x.x",
+          "value": "$1.x.x"
+        }
       }
     ]
   },


### PR DESCRIPTION
## Summary
- document masking instructions in README
- add text-box variables for IP masking
- apply regex-based masking transform to Apache and MySQL dashboards

## Testing
- `shellcheck scripts_honeypot/07_promtail.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f130e9dc8832a81baf0f45c691955